### PR TITLE
2.1.2.CLI.既存プロジェクト情報の一覧リスト取得

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,49 @@ Refer to [docs/Template_file_design.xlsx](docs/Template_file_design.xlsx) for te
 
 Refer to [docs/sample](docs/sample) for template sample.
 
+#### 既存プロジェクト情報の一覧リスト取得
+The following functions are possible:
+- Get the project list belonging to the currently logged-in user .
+
+**\* Notice** about getting the project list:  
+- Get all projects belonging to the user, output information includes: the project name and GUID, no component information.
+
+##### Usages
+Get help and see available commands, get help on a specific command
+```cmd
+grdmcli --help
+grdmcli projects --help
+grdmcli projects list --help
+```
+
+Example for getting user's project list function 
+```text
+$ grdmcli projects list --help
+usage: grdmcli projects list [-h]
+                             [--output_result_file OUTPUT_RESULT_FILE]
+                             [--display_console]
+                             [--osf_token OSF_TOKEN]
+                             [--osf_api_url OSF_API_URL]
+                             [--disable_ssl_verify]
+                             [--debug]
+                             [--verbose]
+
+projects list command
+
+options:
+  -h, --help            show this help message and exit
+  --output_result_file OUTPUT_RESULT_FILE
+                        The output result file path
+  --display_console     Output result to console screen
+  --osf_token OSF_TOKEN
+                        The Personal Access Token
+  --osf_api_url OSF_API_URL
+                        The API URL
+  --disable_ssl_verify  Disable SSL verification
+  --debug               Enable Debug mode
+  --verbose             Enable Verbose mode
+```
+
 ### How to run UT TCs
 - To run test code in the `test` module,  
 Ensure the following packages in `requirements.txt` are installed:

--- a/docs/sample/output_get_project_list.json
+++ b/docs/sample/output_get_project_list.json
@@ -1,0 +1,16 @@
+{
+    "projects": [
+        {
+            "id": "fvpuj",
+            "title": "N_Test_01"
+        },
+        {
+            "id": "yanxg",
+            "title": "Test_01"
+        },
+        {
+            "id": "bkmp9",
+            "title": "projne"
+        }
+    ]
+}

--- a/grdmcli/__main__.py
+++ b/grdmcli/__main__.py
@@ -6,6 +6,7 @@ import logging
 import sys
 
 import six
+from pathvalidate.argparse import validate_filepath_arg
 
 from . import __version__
 from . import constants as const  # noqa
@@ -70,6 +71,19 @@ def main():
                                         help='The output result file path')
     # to add config args
     _have_config_parsers.append(projects_create_parser)
+
+    # block command=list
+    projects_list_parser = _add_subparser(projects_cmd_subparsers, 'list', 'projects list command')
+    projects_list_parser.set_defaults(func='projects_get_list')
+    # to add template arg
+    projects_list_parser.add_argument('--output_result_file',
+                                      help='The output result file path',
+                                      type=validate_filepath_arg)
+    projects_list_parser.add_argument('--display_console',
+                                      action='store_true',
+                                      help='Output result to console screen')
+    # to add config args
+    _have_config_parsers.append(projects_list_parser)
 
     # [END] block entity=projects
 

--- a/grdmcli/grdm_client/__init__.py
+++ b/grdmcli/grdm_client/__init__.py
@@ -40,6 +40,7 @@ class GRDMClient(CommonCLI):
         _projects_add_component,
         _create_or_load_project,
         projects_create,
+        projects_get_list
     )
     template_schema_projects = property(_get_template_schema_projects)
     # For contributors functions

--- a/grdmcli/grdm_client/common.py
+++ b/grdmcli/grdm_client/common.py
@@ -41,6 +41,7 @@ class CommonCLI(Namespace):
         self.config_default = {}
         self.template = const.TEMPLATE_FILE_NAME_DEFAULT
         self.output_result_file = const.OUTPUT_RESULT_FILE_NAME_DEFAULT
+        self.display_console = False
 
         self.user = None
         self.is_authenticated = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ validators~=0.20.0
 jsonschema~=2.6.0
 requests~=2.27.1
 six~=1.12.0
+pathvalidate==3.2.0
 
 # for testing
 pytest==7.3.1

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -148,6 +148,7 @@ class CommonCLIFactory(Namespace):
         self.user = None
         self.template = 'path-to-template'
         self.output_result_file = 'path-to-write-file'
+        self.display_console = False
         self.affiliated_institutions = []
         self.affiliated_users = []
         self.projects = []

--- a/tests/test_grdm_client/test_init.py
+++ b/tests/test_grdm_client/test_init.py
@@ -19,3 +19,4 @@ def test_init__grdm_client():
     assert grdm_client.created_projects == []
     # For contributors functions
     assert grdm_client.created_project_contributors == []
+    assert grdm_client.display_console is False

--- a/tests/test_grdm_client/test_projects.py
+++ b/tests/test_grdm_client/test_projects.py
@@ -318,7 +318,18 @@ get_project_str = json.dumps({
                 "self": "http://localhost:8000/v2/nodes/wguvp/"
             }
         }
-    ]
+    ],
+    "links": {
+        "last": "http://localhost:8000/v2/users/jdm2p/nodes/?page=100&page%5Bsize%5D=10&sort=pk",
+        "next": "http://localhost:8000/v2/users/jdm2p/nodes/?page=2&page%5Bsize%5D=10&sort=pk",
+        "meta": {
+            "total": 6,
+            "per_page": 3
+        }
+    },
+    "meta": {
+        "version": "2.0"
+    }
 })
 
 content_obj = json.loads(_content, object_hook=lambda d: SimpleNamespace(**d))


### PR DESCRIPTION
## Purpose

- Create a new "grdmcli projects list" command to get all projects belonging to the user, output information includes the project name and GUID, no component information. 

## Changes

- Define a new command: `grdmcli projects list`.
- Add the `projects_get_list` function to get the project list and synthesize output data.
- Add UT Test for the `grdmcli projects list` command.
- Add 1 new package: `pathvalidate` version: 3.2.0.
- Add a description for the new command `grdmcli projects list`.

## QA Notes

None.

## Documentation

None.

## Side Effects

None.

## Ticket

None.